### PR TITLE
Error handling and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
 name = "ascii"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +287,7 @@ dependencies = [
 name = "reg2hdf-prototype"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "chrono",
  "hdf5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.58"
 byteorder = "1"
 chrono = "0.4"
 hdf5 = "0.8.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::prelude::*;
 use std::io::Cursor;
-use std::io::{SeekFrom};
-use chrono::prelude::*;
-use hdf5::{File, H5Type, Result};
+use std::io::SeekFrom;
 
+use anyhow::Result;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use chrono::prelude::*;
+use hdf5::File;
 
 #[derive(Debug)]
 struct FpgaData {
@@ -14,9 +15,8 @@ struct FpgaData {
     wave_2: Vec<u16>,
     wave_3: Vec<u16>,
     wave_4: Vec<u16>,
-    wave_5: Vec<u16>
+    wave_5: Vec<u16>,
 }
-
 
 fn main() -> Result<()> {
     //println!("Hello, world!");
@@ -26,11 +26,11 @@ fn main() -> Result<()> {
     //println!("{}", array.len());
     let mut test_buffer = Cursor::new(&array[..]);
     let n = 2700;
-    let _ret = test_buffer.seek(SeekFrom::Start((n-1)*2));
-    let read = test_buffer.read_u16::<LittleEndian>();
+    test_buffer.seek(SeekFrom::Start((n - 1) * 2))?;
+    test_buffer.read_u16::<LittleEndian>()?;
     //println!("{:?}", read);
     //println!("The {}th element is: {:?}", n, read);
-    let _ret = test_buffer.rewind();
+    test_buffer.rewind()?;
     /*let wave_1 = read_waveform_from_offset(512, 4*512, &mut test_buffer);
     let wave_2 = read_waveform_from_offset(512, 3*512, &mut test_buffer);
     let wave_3 = read_waveform_from_offset(512, 2*512, &mut test_buffer);
@@ -45,51 +45,55 @@ fn main() -> Result<()> {
     let data = FpgaData {
         count: 0,
         timestamp: (utc.timestamp(), utc.timestamp_subsec_nanos()),
-        wave_1: wave_1,
-        wave_2: wave_2,
-        wave_3: wave_3,
-        wave_4: wave_4,
-        wave_5: wave_5
+        wave_1,
+        wave_2,
+        wave_3,
+        wave_4,
+        wave_5,
     };
     println!("{}", test_buffer.position());
     //println!("{:?}", data);
     let hdffile = File::create("test_hdf5.h5")?;
     //println!("{:?}", hdffile);
     let wave_group = hdffile.create_group("waves")?;
-    let builder = wave_group.new_dataset_builder();
-    let ds = builder
+    wave_group
+        .new_dataset_builder()
         .with_data(&data.wave_1)
-        .create("wave_1");
-    let builder = wave_group.new_dataset_builder();
-    let ds = builder
+        .create("wave_1")?;
+    wave_group
+        .new_dataset_builder()
         .with_data(&data.wave_2)
-        .create("wave_2");
-    let builder = wave_group.new_dataset_builder();
-    let ds = builder
+        .create("wave_2")?;
+    wave_group
+        .new_dataset_builder()
         .with_data(&data.wave_3)
-        .create("wave_3");
-    let builder = wave_group.new_dataset_builder();
-    let ds = builder
+        .create("wave_3")?;
+    wave_group
+        .new_dataset_builder()
         .with_data(&data.wave_4)
-        .create("wave_4");
-    let builder = wave_group.new_dataset_builder();
-    let ds = builder
+        .create("wave_4")?;
+    wave_group
+        .new_dataset_builder()
         .with_data(&data.wave_5)
-        .create("wave_5");
+        .create("wave_5")?;
     Ok(())
 }
 
-fn read_waveform_from_offset(read_len: usize, offset: u64, buffer: &mut Cursor<&[u8]>) -> Vec<u16> {
+fn read_waveform_from_offset(
+    read_len: usize,
+    offset: u64,
+    buffer: &mut Cursor<&[u8]>,
+) -> Result<Vec<u16>> {
     let mut out_buffer = vec![0; read_len];
-    let _ret = buffer.seek(SeekFrom::Start(offset));
-    let _ret = buffer.read_u16_into::<LittleEndian>(&mut out_buffer).unwrap();
-    out_buffer
+    buffer.seek(SeekFrom::Start(offset))?;
+    buffer.read_u16_into::<LittleEndian>(&mut out_buffer)?;
+    Ok(out_buffer)
 }
 
 fn read_waveform_from_cursor(read_len: usize, buffer: &mut Cursor<&[u8]>) -> Vec<u16> {
     let mut out_buffer = vec![0; read_len];
-    //let _ret = buffer.seek(SeekFrom::Start(offset));
-    let _ret = buffer.read_u16_into::<LittleEndian>(&mut out_buffer).unwrap();
+    //buffer.seek(SeekFrom::Start(offset))?;
+    buffer.read_u16_into::<LittleEndian>(&mut out_buffer);
     out_buffer
 }
 


### PR DESCRIPTION
Rust handles errors by returning Result<T, E> from functions, a sum type
that's eithre the result you wanted (T) or some error (E). For those who
don't like typing boilerplate all day, it has a `?` operator, where

    let f = foo()?

has the same meaning as

    let f = match foo() {
        Ok(k) => k, // Get the successful result
        err => return err, // Or return from the function with err
    };

Warnings about unused results are usually indications that you should do
something with the error value. You can also use `.unwrap()` to assert
that the result isn't an error, but you should generally avoid this
unless you would only get an error in the event of a bug, e.g.,

    // Only returns error if you fat-thumbed an invalid regex:
    let match_digits = Regex::new("[0-9]+").unwrap();

For applications, we often want to just propagate an error back up to
main(), print a complaint, and exit the program. For Pokemon error
handling like this (gotta catch em all!), the anyhow crate is the de
facto standard: https://docs.rs/anyhow/latest/anyhow/
Another nicety it gives us is that you can attach additional context to
errors very easily, e.g.,

    File::open(conf_path).context("Couldn't open config file")?;

or even

    File::open(conf_path).with_context(
        || format!("Couldn't open {conf_path}))?;